### PR TITLE
Fix incorrect file size calculation

### DIFF
--- a/apps/client/src/utils/index.ts
+++ b/apps/client/src/utils/index.ts
@@ -13,8 +13,7 @@ export function formatBytes(bytes: string | number, decimals = 2) {
   const sizes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
 
   const i = Math.floor(Math.log(_bytes) / Math.log(k));
-
-  return `${parseFloat((_bytes / k ** 1).toFixed(dm))} ${sizes[i]}`;
+  return `${parseFloat((_bytes / k ** i).toFixed(dm))} ${sizes[i]}`;
 }
 
 export default {


### PR DESCRIPTION
After a few reports of incorrect file sizes (which both happened to be for compressed folders), I looked over the code that converts the size of the file in bytes to human readable form and noticed a typo........

Closes #13.