### PR TITLE
Update CLI `upload` function to accept path to file

### DIFF
--- a/apps/landing/content/cli/3.4.1.md
+++ b/apps/landing/content/cli/3.4.1.md
@@ -1,0 +1,142 @@
+---
+createdAt: February 1, 2022
+updatedAt: February 1, 2022
+---
+
+**Create Space**
+
+`floatingfile create`
+
+**Destroy Space**
+
+`floatingfile destroy`
+
+Options:
+
+- `-c`, `--code`: Code of the space to destroy. If no code is provided, will fallback to the most recently accessed space if available. [string]
+
+**List Recently Accessed Spaces**
+
+`floatingfile spaces`
+
+Options:
+
+- `--def`: Suppply this flag to interactively set a new default space. [boolean]
+
+**Upload Files** _(changed from v3.4.0)_
+
+`floatingfile upload [path]`
+
+Positionals:
+
+- `path`: Path to file or directory to upload files from. [string]
+
+Options:
+
+- `-c`, `--code`: Code of the space to upload files to. If no code is provided, will fallback to the most recently accessed space if available. [string]
+
+- `-a`, `--all`: Upload all files within the directory. This flag will only be used if the path provided is a path to a directory. [boolean]
+
+Examples:
+
+```
+$ floatingfile upload ~/Desktop/test_files/ --code=ABC123
+> >> floatingfile
+> (0) .DS_Store
+> (1) Screen Recording 2022-01-13 at 01.06.54.mov
+> (2) Screen Shot.png
+> Which files do you want to upload?
+$ 2
+> [=====================] 100% | 41339/41339 bytes | Screen Shot.png
+>
+> Successfully uploaded:
+> /Users/garethlau/Desktop/Screen Shot.png
+```
+
+**Remove Files**
+
+`floatingfile remove`
+
+Options:
+
+- `-c`, `--code`: Code of the space to remove files from. If no code is provided, will fallback to the most recently accessed space if available. [string]
+
+- `-a`, `--all`: Remove all files from the space. [boolean]
+
+**List Files**
+
+`floatingfile files`
+
+Options:
+
+- `-c`, `--code`: Code of the space to list files from. If no code is provided, will fallback to the most recently accessed space if available. [string]
+
+**Download Files**
+
+`floatingfile download [dir]`
+
+Positionals:
+
+- `dir`: Directory to download files to. If not provided, will fallback to default download directory. See config. [string]
+
+Options:
+
+- `-c`, `--code`: Code of the space to to download files from. If no code is provided, will fallback to the most recently accessed space if available. [string]
+
+- `-a`, `--all`: Download all the files in the space. [boolean]
+
+Examples:
+
+```
+$ floatingfile download ~/Downloads -a
+> >>> floatingfile
+> Are you sure you want to download all 1 files? (y/n)
+$ y
+> [=====================] 100% 41339/41339 bytes | picture.png
+>
+> Successfully downloaded:
+> /Users/garethlau/Downloads/picture.png
+```
+
+**Read or Update Configurations**
+
+`floatingfile config [<key>] [<value>]`
+
+Positionals:
+
+- `key` - The name of the configuration to view or update. See below for a list of possible keys. [string]
+- `value` - New value to set the configuration to. [string]
+
+Options:
+
+- `-l`, `--list` - List all configurations. [boolean]
+
+Examples:
+
+_Read a Property_
+
+```
+$ floatingfile config username
+> username=CLI
+```
+
+_Set a Property_
+
+```
+$ floatingfile config username Spiderman
+```
+
+_View all_
+
+```
+$ floatingfile config -l
+> username=Spiderman
+> download_to=Desktop/floatingfile
+> group_by_space=Yes
+```
+
+Possible Keys:
+
+- `username` - The username other users will see you as. By default, this is set to `CLI`.
+- `download_to` - Detault path for file downloads. By default, this is set to `Downloads`.
+- `group_by_space` - If set to "Yes", downloaded files will be placed into a directory with the space's code as the directory name. By default, this is set to "No".


### PR DESCRIPTION
Closes #14 . 

This PR adds a check for the supplied path to check whether it is a directory or file. This enables users to directly upload files like so:

```
floatingfile upload ./test-file.txt
```

Created a new documentation set for the CLI to reflect this change.